### PR TITLE
Update regexp.md,增加脱字符示例

### DIFF
--- a/docs/stdlib/regexp.md
+++ b/docs/stdlib/regexp.md
@@ -547,10 +547,11 @@ str.split(separator, [limit])
 
 ```javascript
 /[^abc]/.test('hello world') // true
+/[^abc]/.test('bbc news') // true
 /[^abc]/.test('bbc') // false
 ```
 
-上面代码中，字符串`hello world`不包含字母`a`、`b`、`c`中的任一个，所以返回`true`；字符串`bbc`不包含`a`、`b`、`c`以外的字母，所以返回`false`。
+上面代码中，字符串`hello world`不包含字母`a`、`b`、`c`中的任一个，所以返回`true`；字符串`bbc news`包含除字母`a`、`b`、`c`以外的其他字符，所以返回`true`；字符串`bbc`不包含`a`、`b`、`c`以外的字母，所以返回`false`。
 
 如果方括号内没有其他字符，即只有`[^]`，就表示匹配一切字符，其中包括换行符。相比之下，点号作为元字符（`.`）是不包括换行符的。
 


### PR DESCRIPTION
增加脱字符的示例，防止歧义。 原有示例：
>>>
```javascript
/[^abc]/.test('hello world') // true
```
>>> 上面代码中，字符串`hello world`不包含字母`a`、`b`、`c`中的任一个，所以返回`true`；
可能引起误解：不能包含a,b,c才能返回true