### PR TITLE
Location.host 不包括冒号

### DIFF
--- a/docs/bom/location.md
+++ b/docs/bom/location.md
@@ -12,7 +12,7 @@ URL 是互联网的基础设施之一。浏览器提供了一些原生对象，�
 
 - `Location.href`：整个 URL。
 - `Location.protocol`：当前 URL 的协议，包括冒号（`:`）。
-- `Location.host`：主机，包括冒号（`:`）和端口（默认的80端口和443端口会省略）。
+- `Location.host`：主机名和端口（默认的80端口和443端口会省略）。
 - `Location.hostname`：主机名，不包括端口。
 - `Location.port`：端口号。
 - `Location.pathname`：URL 的路径部分，从根路径`/`开始。


### PR DESCRIPTION
<img width="207" alt="屏幕快照 2019-08-08 16 02 39" src="https://user-images.githubusercontent.com/37589122/62686054-84a4d880-b9f6-11e9-8570-bf26b9a8d9c8.png">

阮老师，location.host 输出结果应该不包括冒号，只有主机名和端口号。