### PR TITLE
fix(8.6): 2.10案例错误

### DIFF
--- a/docs/dom/element.md
+++ b/docs/dom/element.md
@@ -371,8 +371,8 @@ document.body.scrollHeight
 
 ```javascript
 // HTML 代码如下
-// <div id="myDiv" style="height: 200px; overflow: hidden;">...</div>
-document.getElementById('myDiv').scrollHeight // 200
+// <div id="myDiv" style="height: 200px; overflow: hidden;"><div style="height: 350px;">内容高度350px</div></div>
+document.getElementById('myDiv').scrollHeight // 350
 ```
 
 上面代码中，即使`myDiv`元素的 CSS 高度只有200像素，且溢出部分不可见，但是`scrollHeight`仍然会返回该元素的原始高度。

--- a/docs/dom/element.md
+++ b/docs/dom/element.md
@@ -375,7 +375,7 @@ document.body.scrollHeight
 document.getElementById('myDiv').scrollHeight // 350
 ```
 
-上面代码中，即使`myDiv`元素的 CSS 高度只有200像素，且溢出部分不可见，但是`scrollHeight`仍然会返回该元素的原始高度。
+上面代码中，即使`myDiv`元素的 CSS 高度只有200像素，且溢出部分不可见，但是`scrollHeight`仍然会返回该元素的总高度。
 
 ### Element.scrollLeft，Element.scrollTop
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/33f07da9-5c6b-47ee-94cc-9bd6e08f72c1)
此处案例联系上下文本意是内容溢出`scrollHeight`属性仍然返回元素的总高度，补充了一下案例